### PR TITLE
Bugfix: 'Paylane Error: Description is not valid' at CreditCard payment

### DIFF
--- a/class/CreditCard.php
+++ b/class/CreditCard.php
@@ -341,7 +341,7 @@ class CreditCard extends PaymentMethodAbstract
 
         $data['amount'] = sprintf('%01.2f', $cart->getOrderTotal());
         $data['currency'] = $currency->iso_code;
-        $data['description'] = $cart->id;
+        $data['description'] = 'CartID #'.$cart->id;
 
         if (!empty($paymentParams['id_sale'])) {
             $result = $this->client->resaleBySale($data);

--- a/paylane.php
+++ b/paylane.php
@@ -26,7 +26,7 @@
 
 require_once(dirname(__FILE__).'/core/core.php');
 
-// prestashop 1.7
+// prestashop 1.7  // more test
 //use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
 
 if (!defined('_PS_VERSION_')) {

--- a/paylane.php
+++ b/paylane.php
@@ -26,7 +26,7 @@
 
 require_once(dirname(__FILE__).'/core/core.php');
 
-// prestashop 1.7  // more test
+// prestashop 1.7
 //use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
 
 if (!defined('_PS_VERSION_')) {


### PR DESCRIPTION
Adding a fix text to description avoids error "Paylane Error: Description is not valid" during payment process for CartIDs 1 to 9. They are single digit only and a single digit description isn't accepted by PayLane's API.
The description is for information use only, it may contain any text.